### PR TITLE
Virtual environment support

### DIFF
--- a/install-daemon.py
+++ b/install-daemon.py
@@ -54,7 +54,7 @@ def setup(args):
     out = systemd_user_dir / unit_name
     print(f"Writing systemd config to {out}:")
 
-    server_bin = Path(__file__).absolute().parent / "main.py"
+    server_bin = Path(__file__).absolute().parent / "main.sh"
     out.write_text(
         _SystemdConfigTemplate.format(
             service_name=common.app_name_human, server=server_bin

--- a/main.sh
+++ b/main.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+
+cwd=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
+
+pushd $cwd
+source venv/bin/activate
+python3 main.py

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+
+cwd=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
+
+python3 -m venv venv
+source venv/bin/activate
+python3 -m pip install -r requirements.txt


### PR DESCRIPTION
Adds support for using a virtual environment instead of installing pip packages globally.
`setup.sh` creates the virtual environment and installs the dependencies
`main.sh` sources the virtual environment and calls `main.py`. 
`install-daemon.py` now uses `main.sh` as the binary to run.